### PR TITLE
Correction while getting children from dom

### DIFF
--- a/VueSwing.vue
+++ b/VueSwing.vue
@@ -22,7 +22,8 @@ export default {
 
   mounted () {
     this.stack = Swing.Stack(this.config || {})
-    for (let el of this.$el.children) {
+    let children = [].slice.call(this.$el.children)
+    for (let el of children) {
       this.cards.push(this.stack.createCard(el))
     }
 

--- a/VueSwing.vue
+++ b/VueSwing.vue
@@ -22,10 +22,10 @@ export default {
 
   mounted () {
     this.stack = Swing.Stack(this.config || {})
-    let children = [].slice.call(this.$el.children)
-    for (let el of children) {
+    let children = [...this.$el.children]
+    children.forEach(el => {
       this.cards.push(this.stack.createCard(el))
-    }
+    })
 
     // Observe changes in DOM
     this.observer = new MutationObserver(mutations => {


### PR DESCRIPTION
When we use **for (let el of this.$el.children) {** it happens to the for loose it self because **this.stack.createCard(el)** manipulate the cards list.

![image](https://user-images.githubusercontent.com/2214768/34444507-c68041d2-ecb5-11e7-9fba-f880cf375370.png)

So, instead of using just **for (let el of this.$el.children) {**, I suggest to use:
**let children = [].slice.call(this.$el.children); 
for (let el of children) {**

Just like the original source code from swing.

